### PR TITLE
Adding events and progress monitoring to Uize.Comm.Ajax

### DIFF
--- a/site-source/js/Uize/Comm/Ajax.js
+++ b/site-source/js/Uize/Comm/Ajax.js
@@ -94,9 +94,6 @@ Uize.module ({
 
 					if (_xmlHttpRequest.upload) { // test if XHR2
 					  _xmlHttpRequest.onprogress = function (_event) {
-					    if (_event.lengthComputable) {
-					      console.log(Math.round(100 * _event.loaded / _event.total));
-					    }
 					    // Pass on the event obj with our event name
 					    _event.name = 'XHR Progress';
 					    m.fire(_event);


### PR DESCRIPTION
This Ajax module now fires three possible events, `XHR Progress`, `XHR Load`, and `XHR Error`. `XHR Progress` fires in the XMLHttpRequest's `onprogress` handler, if available. `XHR Load` and `XHR Error` fire when `onreadystatechange` fires at `readyState == 4`. `XHR Error` fires if the response code is not 200.

The events are fired with the respective data required for the most common use cases.

The changes should be fully backwards compatible.
