### PR TITLE
Proposed Uize.Class stateProperties fix

### DIFF
--- a/site-source/js/Uize/Class.js
+++ b/site-source/js/Uize/Class.js
@@ -1615,6 +1615,7 @@ Uize.module ({
 								_propertyName,
 							_propertyPrimaryPublicName = _propertyPublicName,
 							_propertyProfile = _propertyProfilesByPrivateName [_propertyPrivateName]
+								|| _propertyProfilesByPrivateName [_propertyPublicName] // if not found by private name, try public name in case the property was registered by public name first
 						;
 						_propertyPrivateNameLookup [_propertyPrivateName] = _propertyPrivateName;
 						if (!_propertyProfile) {

--- a/site-source/js/Uize/Test/Uize/Class.js
+++ b/site-source/js/Uize/Test/Uize/Class.js
@@ -2011,6 +2011,34 @@ Uize.module ({
 										var _instance = new _Subclass;
 										return this.expect ({myProperty1:undefined,myProperty2:undefined},_instance.get ());
 									}
+								},
+								{
+									title:'When a state property is first declared with private name and later with public name, the definitions are merged'	,
+									test:function() {
+										var
+											_Subclass = Uize.Class.subclass (),
+											_called = false
+										;
+										_Subclass.stateProperties ({_myProperty1:{name:'myProperty1',value:3}});
+										_Subclass.stateProperties ({myProperty1:{name:'myProperty1',onChange:function() { _called = true}}});
+										var _instance = new _Subclass;
+										_instance.set('myProperty1', 5);
+										return this.expect (true,_called);
+									}
+								},
+								{
+									title:'When a state property is first declared with public name and later with private name, the definitions are merged'	,
+									test:function() {
+										var
+											_Subclass = Uize.Class.subclass (),
+											_called = false
+										;
+										_Subclass.stateProperties ({myProperty1:{name:'myProperty1',onChange:function() { _called = true}}});
+										_Subclass.stateProperties ({_myProperty1:{name:'myProperty1',value:3}});
+										var _instance = new _Subclass;
+										_instance.set('myProperty1', 5);
+										return this.expect (true,_called);
+									}
 								}
 							]
 						},


### PR DESCRIPTION
There's a situation where if you try and register a state property using it's public name first, presumably in a mix-in trying to add an additional `onChange`, and then the actual class registers the state property with its private name, the first registration gets orphaned and change handler is not fired.

The proposed fix is simple. When the state profile is being added by private name and doesn't find an existing profile in the private name lookup, it tries to see if there's a profile for the main private name.

The net result is that you're no longer forced to register state properties before declarations that are mixed in (like `eventBindings`).