### PR TITLE
Latest from Zazzle!

### DIFF
--- a/site-source/js/Uize/Services/FileSystemAdapter/Wsh.js
+++ b/site-source/js/Uize/Services/FileSystemAdapter/Wsh.js
@@ -120,7 +120,10 @@ Uize.module ({
 							_targetPath = _params.targetPath
 						;
 						m._makeFolder (_getParentFolderPath (_targetPath));
-						m._fileSystemObject.CopyFile (_params.path,_targetPath,true);
+						m._writeFile(
+							_targetPath,
+							m._readFile(_params.path)
+						);
 						_callback ();
 					},
 

--- a/site-source/js/Uize/Test/Uize/Loc/FileFormats/ProjectStrings/Xliff.js
+++ b/site-source/js/Uize/Test/Uize/Loc/FileFormats/ProjectStrings/Xliff.js
@@ -139,7 +139,7 @@ Uize.module ({
 											STR4:'{param}',
 											STR5:'{param1}{param2}'
 										}
-									},
+									}
 
 								},
 								{tokenSplitter:/\{[\w\d]+\}/}

--- a/site-source/js/Uize/Widget.js
+++ b/site-source/js/Uize/Widget.js
@@ -1437,7 +1437,7 @@ Uize.module ({
 									_unappliedChildrenPropertiesForChild = _unappliedChildrenProperties [_childName]
 								;
 								if (_unappliedChildrenPropertiesForChild) {
-									_copyInto (_properties,_unappliedChildrenPropertiesForChild);
+									_properties = Uize.copy(_properties, _unappliedChildrenPropertiesForChild);
 									delete _unappliedChildrenProperties [_childName];
 								}
 

--- a/site-source/js/Uize/Widget/Dialog.js
+++ b/site-source/js/Uize/Widget/Dialog.js
@@ -376,38 +376,18 @@ Uize.module ({
 										_mooringCoords = _Uize_Dom_Pos.getCoords(_mooringNode),
 										_rightAligned = m._offsetRegistrationCorner.indexOf('right') > -1,
 										_bottomAligned = m._offsetRegistrationCorner.indexOf('bottom') > -1,
-										_bodyDimensions = _Uize_Dom_Pos.getDimensions(document.body),
-										_stylesToSet = {}
+										_bodyDimensions = _Uize_Dom_Pos.getDimensions(document.body)
 									;
 
-									// horizontal alignment
-									if (_rightAligned)
-										Uize.copyInto(_stylesToSet, {
-											left: 'auto',
-											right: _bodyDimensions.width - _mooringCoords.left - _offsetX
-										});
-									else
-										Uize.copyInto(_stylesToSet, {
-											left: _mooringCoords.left + _offsetX,
-											right: 'auto'
-										});
-
-									// vertical alignment
-									if (_bottomAligned)
-										Uize.copyInto(_stylesToSet, {
-											top: 'auto',
-											bottom: _bodyDimensions.height - _mooringCoords.top - _offsetY
-										});
-									else
-										Uize.copyInto(_stylesToSet, {
-											top: _mooringCoords.top + _offsetY,
-											bottom: 'auto'
-										});
-
 									// set styles
-									_Uize_Dom_Basics.setStyle (
-										_rootNode,
-										_stylesToSet
+									m.setNodeStyle (
+										_rootNode, 
+										{
+											left: _rightAligned ? '' : (_mooringCoords.left + _offsetX),
+											right: _rightAligned ? (_bodyDimensions.width - _mooringCoords.left - _offsetX) : '',
+											top: _bottomAligned ? '' : (_mooringCoords.top + _offsetY),
+											bottom: _bottomAligned ? (_bodyDimensions.height - _mooringCoords.top - _offsetY) : ''
+										}
 									);
 								}
 							}

--- a/site-source/js/Uize/Widget/Dialog/Confirm.js
+++ b/site-source/js/Uize/Widget/Dialog/Confirm.js
@@ -24,86 +24,15 @@
 */
 
 Uize.module ({
-	name:'Uize.Widget.Dialog.Confirm',
+	name: 'Uize.Widget.Dialog.Confirm',
+	required: 'Uize.Widget.Dialog.mConfirm',
 	builder:function (_superclass) {
 		'use strict';
 
-		/*** Private Instance Methods ***/
-			function _updateUiState (m) {
-				m.isWired &&
-					m.setNodeProperties (
-						'icon',
-						{className:'dialogIcon dialog' + Uize.capFirstChar (m._state) + 'Icon'}
-					)
-				;
-			}
-
-			function _updateUiMessage (m) {
-				m.isWired && m._message != null && m.setNodeInnerHtml ('message',m._message);
-			}
-
-			function _updateUiMode (m) {
-				m.isWired && m.children.cancel.showNode ('',!m._mode.indexOf ('confirm'));
-			}
-
-		return _superclass.subclass ({
-			omegastructor:function () {
-				var m = this;
-
-				/*** add event handlers ***/
-					function _handleConfirm(_event) { m.handleConfirm(_event) }
-					m.wire ({
-						Ok:_handleConfirm,
-						Cancel:_handleConfirm,
-						Close:_handleConfirm
-					});
-			},
-
-			instanceMethods:{
-				handleConfirm:function (_event) {
-					this.fire ({name:'Submission Complete',result:_event.name == 'Ok'});
-				},
-
-				updateUi:function () {
-					var m = this;
-					_updateUiState (m);
-					_updateUiMessage (m);
-					_updateUiMode (m);
-					_superclass.doMy (m,'updateUi');
-				}
-			},
-
-			stateProperties:{
-				_message:{
-					name:'message',
-					onChange:function () {_updateUiMessage (this)},
-					value:''
-				},
-				_mode:{
-					name:'mode',
-					onChange:function () {
-						var m = this;
-						m._mode.indexOf ('Custom') < 0 &&
-							m.set ({defaultTitle:m.localize (m._mode == 'confirm' ? 'confirm' : 'attention')})
-						;
-						_updateUiMode (m);
-					},
-					value:'confirm'
-				},
-				_state:{
-					name:'state',
-					onChange:function () {_updateUiState (this)},
-					value:'info'
-					/* NOTES: states that are supported
-						- info (e.g. "i" in blue circle)
-						- warning (e.g. "!" in orange triangle)
-						- error (e.g. "!" in red triangle, or "x" in red circle)
-						- confirm (e.g. "?" in gray speech bubble)
-						- success (e.g. green check mark, or check mark in a circle)
-					*/
-				}
-			}
+		return _superclass.subclass({
+			mixins: Uize.Widget.Dialog.mConfirm
 		});
+		
 	}
 });
 

--- a/site-source/js/Uize/Widget/Dialog/mConfirm.js
+++ b/site-source/js/Uize/Widget/Dialog/mConfirm.js
@@ -1,0 +1,113 @@
+/*______________
+|       ______  |   U I Z E    J A V A S C R I P T    F R A M E W O R K
+|     /      /  |   ---------------------------------------------------
+|    /    O /   |    MODULE : Uize.Widget.Dialog.mConfirm Mixin
+|   /    / /    |
+|  /    / /  /| |    ONLINE : http://www.uize.com
+| /____/ /__/_| | COPYRIGHT : (c)2014 UIZE
+|          /___ |   LICENSE : Available under MIT License or GNU General Public License
+|_______________|             http://www.uize.com/license.html
+*/
+
+/* Module Meta Data
+	type: Mixin
+	importance: 6
+	codeCompleteness: 2
+	docCompleteness: 2
+*/
+
+/*?
+	Introduction
+		The =Uize.Widget.Dialog.mConfirm= mixin module implements features to facilitate the creation of confirm dialogs (dialog subclasses).
+
+		*DEVELOPERS:* `Rachel Lopatin`
+*/
+
+Uize.module ({
+	name: 'Uize.Widget.Dialog.mConfirm',
+	required: 'Uize.Widget.Form',
+	builder:function () {
+		'use strict';
+
+		/*** Private Instance Methods ***/
+		function _updateUiState (m) {
+			m.isWired &&
+				m.setNodeProperties (
+					'icon',
+					{className:'dialogIcon dialog' + Uize.capFirstChar (m.state) + 'Icon'}
+				)
+			;
+		}
+
+		function _updateUiMessage (m) {
+			m.isWired && m.message != null && m.setNodeInnerHtml ('message',m.message);
+		}
+
+		function _updateUiMode (m) {
+			m.isWired && m.children.cancel.showNode ('',!m.mode.indexOf ('confirm'));
+		}
+
+		return function (_class) {
+			_class.declare({
+				omegastructor: function () {
+					var m = this;
+
+					/*** add event handlers ***/
+					function _handleConfirm(_event) { m.handleConfirm(_event) }
+					m.wire({
+						Ok: _handleConfirm,
+						Cancel: _handleConfirm,
+						Close: _handleConfirm
+					});
+				},
+
+				instanceMethods: {
+					handleConfirm: function (_event) {
+						this.fire({ name: 'Submission Complete', result: _event.name == 'Ok' });
+					},
+
+					updateUi: function () {
+						var m = this;
+						_updateUiState(m);
+						_updateUiMessage(m);
+						_updateUiMode(m);
+						_class.superclass.doMy(m, 'updateUi');
+					}
+				},
+
+				stateProperties: {
+					message: {
+						name: 'message',
+						onChange: function () { _updateUiMessage(this) },
+						value: ''
+					},
+					mode: {
+						name: 'mode',
+						onChange: function () {
+							var m = this;
+							m.mode.indexOf('Custom') < 0 &&
+								m.set({ defaultTitle: m.localize(m.mode == 'confirm' ? 'confirm' : 'attention') })
+							;
+							_updateUiMode(m);
+						},
+						value: 'confirm'
+					},
+					state: {
+						name: 'state',
+						onChange: function () { _updateUiState(this) },
+						value: 'info'
+						/* NOTES: states that are supported
+							- info (eg. "i" in blue circle)
+							- warning (eg. "!" in orange triangle)
+							- error (eg. "!" in red triangle, or "x" in red circle)
+							- confirm (eg. "?" in gray speech bubble)
+							- success (eg. green check mark, or check mark in a circle)
+						*/
+					}
+				}
+			});
+		};
+		
+	}
+});
+

--- a/site-source/js/Uize/Widget/Dialog/mForm.js
+++ b/site-source/js/Uize/Widget/Dialog/mForm.js
@@ -1,0 +1,99 @@
+/*______________
+|       ______  |   U I Z E    J A V A S C R I P T    F R A M E W O R K
+|     /      /  |   ---------------------------------------------------
+|    /    O /   |    MODULE : Uize.Widget.Dialog.mForm Mixin
+|   /    / /    |
+|  /    / /  /| |    ONLINE : http://www.uize.com
+| /____/ /__/_| | COPYRIGHT : (c)2014-2015 UIZE
+|          /___ |   LICENSE : Available under MIT License or GNU General Public License
+|_______________|             http://www.uize.com/license.html
+*/
+
+/* Module Meta Data
+	type: Mixin
+	importance: 6
+	codeCompleteness: 100
+	docCompleteness: 2
+*/
+
+/*?
+	Introduction
+		The =Uize.Widget.Dialog.mForm= mixin module implements features to facilitate the creation of form dialogs (dialogs containing forms).
+
+		*DEVELOPERS:* `Rachel Lopatin`, original code contributed by `Zazzle Inc.`
+*/
+
+Uize.module ({
+	name: 'Uize.Widget.Dialog.mForm',
+	required: 'Uize.Widget.Form',
+	builder:function () {
+		'use strict';
+
+		
+
+		return function (_class) {
+			_class.declare ({
+				omegastructor: function () {
+					var
+						m = this,
+						_false = false,
+						_form = m.addChild(
+							'form',
+							m.formWidgetClass,
+							{ useNormalSubmit: _false }
+						)
+					;
+
+					_form.wire({
+						'Changed.okToSubmit': function () {
+							_form.get('okToSubmit')
+								&& m.handleFormValue(
+									function (_info) {
+										m.fire({
+											name: 'Submission Complete',
+											result: _form.get('value'),
+											info: _info
+										});
+
+										m.set({ shown: _false });
+									}
+								)
+							;
+						},
+						'Changed.numWarningsShown': function () {
+							// if the dialog changes height, update the position to prevent the case where the bottom of the dialog gets pushed out of view.
+							m.updateUiPositionIfShown();
+						}
+					});
+
+					m.wire({
+						Ok: function (_event) {
+							_form.submit();
+							_event.abort = true;
+						},
+						'Before Show': function () {
+							if (m.value)
+								_form.set({ value: Uize.clone(m.value) })
+							;
+						},
+						'After Show': function () { _form.updateUi() },
+						'After Hide': function () { _form.reset() }
+					});
+				},
+
+				instanceMethods: {
+					handleFormValue: function (_callback) { _callback() }
+				},
+
+				stateProperties: {
+					formWidgetClass: {
+						name: 'formWidgetClass',
+						value: Uize.Widget.Form
+					},
+					value: 'value'
+				}
+			});
+		};
+	}
+});
+

--- a/site-source/js/Uize/Widget/Dialog/mResizable.js
+++ b/site-source/js/Uize/Widget/Dialog/mResizable.js
@@ -1,0 +1,318 @@
+/*______________
+|       ______  |   U I Z E    J A V A S C R I P T    F R A M E W O R K
+|     /      /  |   ---------------------------------------------------
+|    /    O /   |    MODULE : Uize.Widget.Dialog.mResizable Mixin
+|   /    / /    |
+|  /    / /  /| |    ONLINE : http://www.uize.com
+| /____/ /__/_| | COPYRIGHT : (c)2014 UIZE
+|          /___ |   LICENSE : Available under MIT License or GNU General Public License
+|_______________|             http://www.uize.com/license.html
+*/
+
+/* Module Meta Data
+	type: Mixin
+	importance: 6
+	codeCompleteness: 2
+	docCompleteness: 2
+*/
+
+/*?
+	Introduction
+		The =Uize.Widget.Dialog.mResizable= mixin module implements features to allow dialogs to dynamically resize.
+
+		EXAMPLE
+		............................................................................
+		Uize.module ({
+			required:[
+				'Uize.Widget.Page',
+				'Uize.Widget.Dialog.mResizable'
+			],
+			builder:function () {
+				var page = window.page = Uize.Widget.Page ();
+
+				page.addChild ('resizableDialog',Uize.Widget.Dialog,{resizable:true});
+			}
+		});
+		............................................................................
+
+		In the above example, an anonymous module is being used to require the =Uize.Widget.Page= (page widget) class and the =Uize.Widget.Dialog.mResizable= extension module. Once these two modules are loaded, the =builder= function creates an instance of the page widget and adds a dialog (an instance of the =Uize.Widget.Dialog= class) named =resizableDialog= as a child widget. By specifying the initial state of ={resizable:true}=, the dialog is resizable by the user.
+
+		Things to Note
+			Must Set Resizable To True
+				It is not sufficient to merely require the =Uize.Widget.Dialog.mResizable= module in order for dialogs to be resizable.
+
+				This module only implements the resizability functionality. You still need to enable resizability for specific dialogs, because just making all dialogs resizable by default would have a runtime cost and may not even be appropriate for most cases.
+
+			Requiring Uize.Widget.Dialog Optional
+				If one requires the =Uize.Widget.Dialog.mResizable= extension module, it is not essential to require the =Uize.Widget.Dialog= module, since it is implicit by requiring =Uize.Widget.Dialog.mResizable=.
+
+				However, you may still want to require both as a good practice, since you will technically be creating instances of =Uize.Widget.Dialog= and not =Uize.Widget.Dialog.mResizable=.
+
+			All Subclasses Resizable
+				Because the =Uize.Widget.Dialog.mResizable= module extends the =Uize.Widget.Dialog= module, instances of all subclasses of =Uize.Widget.Dialog= will also be able to be resizable.
+
+				This is provided that the =Uize.Widget.Dialog= module is extended before the subclasses are created. Examples of other dialog subclasses include: =Uize.Widget.Dialog.Confirm=, =Uize.Widget.Dialog.Form=, and =Uize.Widget.Dialog.Form=.
+
+			Forced Resizable Subclasses
+				A dialog subclass can be made resizable so that all newly created instances of that subclass will be resizable right off the bat. This is done by setting the value of the =resizable= state property to =true= on the class, as in the following example...
+
+				EXAMPLE
+				.....................................................................................
+				Uize.require (
+					'Uize.Widget.Dialog.mResizable',
+					function () {
+						(MyNamespace.MyDialog = Uize.Widget.Dialog.subclass ()).set ({resizable:true});
+
+						var
+							myDialog1 = new MyNamespace.MyDialog,                    // resizable
+							myDialog2 = new MyNamespace.MyDialog ({resizable:false}) // non-resizable
+						;
+					}
+				);
+				.....................................................................................
+
+				In the above example, instances of the =MyNamespace.MyDialog= class are automatically resizable. It is still possible to suppress resizability by explicitly setting =resizable= to =false= during construction, as is the case with the =myDialog2= instance created in this example.
+
+		*DEVELOPERS:* `Chris van Rensburg`
+*/
+
+
+Uize.module({
+	name: 'Uize.Widget.Dialog.mResizable',
+	required: [
+		'Uize.Widget.Resizer',
+		'Uize.Dom.Basics',
+		'Uize.Dom.Pos'
+	],
+	builder: function (_class) {
+		'use strict';
+
+		var
+			/*** Variables for Scruncher Optimization ***/
+				_true = true,
+				_false = false,
+				_Uize = Uize,
+
+			/*** Names for Namespaced Privates ***/
+				_privatesNamespace = 'Uize.Widget.Dialog.mResizable.',
+				_pResizer = _privatesNamespace + 'resizer',
+				_pResizerInitialized = _privatesNamespace + 'resizerInitialized'
+		;
+
+		/*** Private Instance Methods ***/
+		function _createResizerIfNecessary(m) {
+			var _resizer = m[_pResizer];
+			if (m.resizable && !_resizer) {
+				(
+					m[_pResizer] = _resizer = m.addChild(
+						'resizer',
+						Uize.Widget.Resizer,
+						{
+							constrain: _false,
+							minHeight: 0,
+							minWidth: 150
+						}
+					)
+					/*?
+						Child Widgets
+							resizer
+								An instance of the =Uize.Widget.Resizer= class, that is used to wire up the resize functionality for the dialog.
+
+								The interface of the =Uize.Widget.Resizer= class can be used to qualify how the dialog is resizable. For example, a dialog could be made only vertically resizable as follows...
+
+								........................................................................
+								Uize.require (
+									[
+										'Uize.Widget.Page',
+										'Uize.Widget.Dialog.mResizable'
+									],
+									function () {
+										var page = window.page = Uize.Widget.Page ();
+
+										page.addChild (
+											'verticallyResizableDialog',Uize.Widget.Dialog,{resizable:true}
+										).children.resizer.set ({
+											fixedX:true
+										});
+									}
+								);
+								........................................................................
+
+								In the above example, notice how the =resizer= child widget is being dereferenced off the =children= property immediately after adding the dialog child widget. This is possible because the =addChild= instance method returns a reference to the child widget being added (the dialog in this case). Setting the =fixedX= state property of the =resizer= instance to =true= causes the dialog to be resizable only in the Y-axis (vertically).
+
+								*NOTE:* For optimization, the =resizer= child widget is only created if a dialog is made resizable by setting its =resizable= state property to =true=. Therefore, be careful to first set a dialog to be resizable before attempting to access the =resizer= child widget for modifying its state.
+					*/
+				).wire({
+					'Changed.inDrag': function (_event) { m.set({ inDrag: _event.newValue }) },
+					'Drag Start': m,
+					'Drag Done': function (_event) {
+						m.set({
+							width: _resizer.get('width'),
+							height: _resizer.get('height')
+						});
+						m.fire(_event);
+					}
+				});
+
+				/*** code to resync resizer position ***/
+				var _syncResizerToDialogPosition = function () {
+					if (m.isWired && m.get('shown')) {
+						var _rootNode = m.getNode();
+						if (_Uize.Dom.Basics.getStyle(_rootNode, 'display') != 'none') {
+							var _rootNodeCoords = _Uize.Dom.Pos.getCoords(_rootNode);
+							_resizer.set({
+								left: _rootNodeCoords.left,
+								top: _rootNodeCoords.top,
+								width: _rootNodeCoords.width,
+								height: _rootNodeCoords.height
+							});
+						}
+					}
+				};
+				m.wire({
+					'After Show': _syncResizerToDialogPosition,
+					'Changed.width': _syncResizerToDialogPosition,
+					'Changed.height': _syncResizerToDialogPosition,
+					'Drag Done': _syncResizerToDialogPosition
+				});
+
+				/*** initialization ***/
+				if (m.isWired) {
+					_initializeResizerNodesIfNecessary(m);
+					m.get('shown') && // sync position, if resizer created after dialog is shown
+						_syncResizerToDialogPosition()
+					;
+					_resizer.wireUi(); // wire up, if resizer created after dialog is wired
+				}
+			}
+		}
+
+		function _initializeResizerNodesIfNecessary(m) {
+			if (m.isWired && m.resizable && !m[_pResizerInitialized]) {
+				m[_pResizerInitialized] = _true;
+				m[_pResizer].set({
+					areaNodes: [m.getNode()],
+					nodeMap: {
+						move: null,
+						shell: document.documentElement
+					}
+				});
+			}
+		}
+
+		function _updateMaximizeUi() {
+			var
+				m = this,
+				_maximize = m.children.maximize,
+				_restore = m.children.restore,
+				_isMaximized = m.get('isMaximized')
+			;
+
+			_maximize && _maximize.displayNode('', !_isMaximized);
+			_restore && _restore.displayNode('', _isMaximized);
+
+		}
+
+		_class.declare({
+			instanceMethods: {
+				atEndOfOmegaStructor: function () {
+					var m = this;
+
+					m.addChild('maximize', _Uize.Widget.Button).wire('Click', function () { m.set({ isMaximized: _true }) });
+					m.addChild('restore', _Uize.Widget.Button).wire('Click', function () { m.set({ isMaximized: _false }) });
+
+					_createResizerIfNecessary(m);
+				},
+
+				afterWireUi: function () {
+					var m = this;
+					m.wireNode(window, 'resize', function () {
+						//This will resize the dialog to fit the screen if it is already maximized
+						m.get('isMaximized') && m.updateUiDimsIfShown();
+					});
+
+					_updateMaximizeUi.call(m);
+					_initializeResizerNodesIfNecessary(m);
+				},
+
+				updateUiDimsIfShown: function () {
+					var
+						m = this,
+						_nodeToSetDimension = m.get('nodeToSetDimension')
+					;
+					if (m.isWired && m.get('shown') && !m.get('inDrag')) {
+						if (!m.get('isMaximized')) {
+							m.setNodeStyle(_nodeToSetDimension, { width: m.get('width'), height: m.get('height') });
+							//m.setNodeStyle('', { width: m.get('width') });
+						} else {
+							var
+								_contentDims = _Uize.Dom.Pos.getDimensions(m.getNode(_nodeToSetDimension)),
+								_rootDims = _Uize.Dom.Pos.getDimensions(m.getNode()),
+								_windowCoords = _Uize.Dom.Pos.getCoords(window)
+							;
+							m.setNodeStyle(
+								'',
+								{
+									top: window.pageYOffset,
+									left: 0,
+									height: 'auto',
+									width: 'auto'
+								}
+							);
+							m.setNodeStyle(
+								_nodeToSetDimension,
+								{
+									width: _windowCoords.width - (_rootDims.width - _contentDims.width),
+									height: _windowCoords.height - (_rootDims.height - _contentDims.height)
+								}
+							);
+						}
+					}
+				}
+			},
+
+			stateProperties: {
+				resizable: {
+					name: 'resizable',
+					onChange: function () {
+						var
+							m = this,
+							_resizer = m[_pResizer]
+						;
+						_createResizerIfNecessary(m);
+						_initializeResizerNodesIfNecessary(m);
+						_resizer && _resizer.set({ enabled: m.resizable ? 'inherit' : _false });
+					}
+					/*?
+						State Properties
+							resizable
+								A boolean, specifying whether or not the dialog should be resizable.
+
+								The value of this property can be changed at any time: before the dialog widget is wired, after it is wired but before it is shown, after it is shown, etc. The first time that this property becomes =true=, the =resizer= child widget is added to the dialog widget.
+
+								NOTES
+								- the initial value is =undefined= (equivalent to =false=)
+					*/
+				},
+				isMaximized: {
+					name: 'isMaximized',
+					onChange: [
+						'updateUiDimsIfShown',
+						'updateUiPositionIfShown',
+						_updateMaximizeUi
+					],
+					value: _false
+					/*?
+						State Properties
+							isMaximized
+								A boolean, specifying whether or not the dialog is maximized.
+
+								NOTES
+								- the initial value is =false=
+					*/
+				}
+			}
+		});
+	}
+});
+

--- a/site-source/js/Uize/Widget/FormDialog.js
+++ b/site-source/js/Uize/Widget/FormDialog.js
@@ -26,70 +26,12 @@
 Uize.module ({
 	name:'Uize.Widget.FormDialog',
 	superclass:'Uize.Widget.Dialog',
-	required:'Uize.Widget.Form',
+	required: 'Uize.Widget.Dialog.mForm',
 	builder:function (_superclass) {
 		'use strict';
 
-		return _superclass.subclass ({
-			omegastructor:function () {
-				var
-					m = this,
-					_false = false,
-					_form = m.addChild(
-						'form',
-						m._formWidgetClass,
-						{useNormalSubmit:_false}
-					)
-				;
-
-				_form.wire({
-					'Changed.okToSubmit': function () {
-						_form.get('okToSubmit')
-							&& m.handleFormValue(
-								function (_info) {
-									m.fire ({
-										name:'Submission Complete',
-										result:_form.get('value'),
-										info:_info
-									});
-
-									m.set({shown:_false});
-								}
-							)
-						;
-					},
-					'Changed.numWarningsShown': function () {
-						// if the dialog changes height, update the position to prevent the case where the bottom of the dialog gets pushed out of view.
-						m.updateUiPositionIfShown();
-					}
-				});
-
-				m.wire({
-					Ok:function (_event) {
-						_form.submit();
-						_event.abort = true;
-					},
-					'Before Show':function () {
-						if (m._value)
-							_form.set({value:Uize.clone(m._value)})
-						;
-					},
-					'After Show':function () { _form.updateUi() },
-					'After Hide':function () { _form.reset() }
-				});
-			},
-
-			instanceMethods:{
-				handleFormValue:function (_callback) { _callback() }
-			},
-
-			stateProperties:{
-				_formWidgetClass:{
-					name:'formWidgetClass',
-					value:Uize.Widget.Form
-				},
-				_value:'value'
-			}
+		return _superclass.subclass({
+			mixins: Uize.Widget.Dialog.mForm
 		});
 	}
 });

--- a/site-source/js/Uize/Widget/FormElement/Text.js
+++ b/site-source/js/Uize/Widget/FormElement/Text.js
@@ -51,6 +51,12 @@ Uize.module ({
 					}
 				];
 			}
+			
+			function _updateUiMaxLength () {
+				this.isWired
+					&& this.setNodeProperties('input', {maxLength:this._maxLength})
+				;
+			}
 
 			function _updateUiPlaceholder () {
 				this.isWired
@@ -156,6 +162,7 @@ Uize.module ({
 
 				updateUi:function () {
 					if (this.isWired) {
+						_updateUiMaxLength.call (this);
 						_updateUiPlaceholder.call (this);
 						_superclass.doMy (this,'updateUi');
 					}
@@ -196,7 +203,10 @@ Uize.module ({
 				},
 				_maxLength:{
 					name:'maxLength',
-					onChange:_updateMoreValidators,
+					onChange:[
+						_updateUiMaxLength,
+						_updateMoreValidators
+					],
 					value:32767
 				}
 			}

--- a/site-source/js/Uize/Widget/Page.js
+++ b/site-source/js/Uize/Widget/Page.js
@@ -235,7 +235,14 @@ Uize.module ({
 							/* NOTE:
 								Need to break synchronous execution of the page between HTML injection and child widget adoption so the browser has time to insert any widget data into the window object
 							*/
-							setTimeout (function () { _adoptChildWidgets (m,_callback) }, 0);
+							setTimeout(function () {
+							    try {
+							        _adoptChildWidgets(m, _callback);
+							    } catch (err) {
+							        _loaderDirectives.errorCallback && _loaderDirectives.errorCallback(err);
+							        throw err;
+							    }
+							}, 0);
 						}
 
 						_loaderDirectives.beforeInject

--- a/site-source/js/Uize/Widget/Picker.js
+++ b/site-source/js/Uize/Widget/Picker.js
@@ -128,7 +128,8 @@ Uize.module ({
 									picker:m,
 									mooringNode:_mooringNode,
 									offsetX:_mooringNodeDims.width >> 1,
-									offsetY:_mooringNodeDims.height >> 1
+									offsetY: _mooringNodeDims.height >> 1,
+									preventPageScrollWhenShown: m._dialogPreventScrollWhenShown
 								},
 								m.getDialogWidgetProperties(),
 								m.get ((m._pipedProperties || []).concat ('value', 'valueDetails'))
@@ -185,6 +186,10 @@ Uize.module ({
 								NOTES
 								- the initial value is =undefined=
 					*/
+				_dialogPreventScrollWhenShown: {
+					name: 'dialogPreventScrollWhenShown',
+					value: false
+				},
 				_pipedProperties:'pipedProperties',
 					/*?
 						State Properties

--- a/site-source/js/Uize/Widget/Resizer.js
+++ b/site-source/js/Uize/Widget/Resizer.js
@@ -271,9 +271,12 @@ Uize.module ({
 										_handleName,
 										_Uize_Widget_Drag,
 										{
-											cursor:_handleName == 'move'
-												? _handleName
-												: _handleName.charAt (0) + (_handleName.match (/[A-Z]|$/)) [0] + '-resize',
+											cursor: m._useDefaultCursors
+												? (_handleName == 'move'
+													? _handleName
+													: _handleName.charAt (0) + (_handleName.match (/[A-Z]|$/)) [0] + '-resize'
+													)
+												: false,
 											dragRestTime:m._dragRestTime,
 											node:m.getNode (_handleName),
 											resizerInfo:{
@@ -290,7 +293,7 @@ Uize.module ({
 												m._activeHandle = _event.source;
 												m.set ({_inDrag:_true});
 												_updateShellBoundsAndConformDims.call (m);
-												_bounds = m._bounds;
+												_bounds = m._bounds || [0, 0, 0, 0];
 												_shellCenter = [_bounds [2] / 2,_bounds [3] / 2];
 												_dragStartCoords = [
 													m._left,
@@ -534,6 +537,10 @@ Uize.module ({
 					name:'top',
 					onChange:_conformDimsAndUpdateUi,
 					value:0
+				},
+				_useDefaultCursors: {
+					name: 'useDefaultCursors',
+					value: _true
 				},
 				_width:{
 					name:'width',

--- a/site-source/js/Uize/Widget/TextInput.js
+++ b/site-source/js/Uize/Widget/TextInput.js
@@ -293,6 +293,9 @@ Uize.module ({
 						if (m._filterType == 'LAN' && /[^a-z0-9]/.test (_value))
 							_value = _value.toLowerCase ().replace(/[^a-z0-9]/g,'')
 						;
+						if (m._filterType == 'NUM' && /[^0-9]/.test(_value))							
+							_value = _value.toLowerCase().replace(/[^0-9]/g, '')
+						;
 						if (_value.length > _maxLength)
 							_value = _value.slice (0,_maxLength)
 						;
@@ -308,6 +311,7 @@ Uize.module ({
 				_filterType:'filterType'
 					/***
 					LAN - lowerAlphaNumeric
+					NUM - numbers
 					***/
 			}
 		});


### PR DESCRIPTION
- Updating Uize.Widget to clone properties when applying unappliedChildPropertiesForChild. It's possible that the passed in properties to addChild could be reused and overwriting can cause problems
- In Uize.Services.FileSystemAdapter.Wsh we accidentally overwrote code in copyFile to mimic what the Node service does
- dangling comma fix in Xliff.js and HtmltCompiler.js
- cleaned up code in Uize.Widget.Dialog for determining rootnode pinning
- FormDialog code factored out into Uize.Widget.Dialog.mForm
- Error handling for child widget adopting when calling loadHtmlIntoNode in Uize.Widget.Page
- Confirm dialog factored out into Uize.Widget.Dialog.mConfirm
- Other misc bug fixes