### PR TITLE
Changing Uize Overrides

### DIFF
--- a/site-source/js/Uize.js
+++ b/site-source/js/Uize.js
@@ -6073,5 +6073,5 @@ Uize = (function (_UizeOverrides) {
 		_package.addFolderOrgNamespaces ('Uize');
 		_package.module ({name:'Uize',builder:function () {return _package}});
 
-		return _package;
+	return _package;
 }) ((function () {return this}) ().Uize);

--- a/site-source/js/Uize.js
+++ b/site-source/js/Uize.js
@@ -407,17 +407,17 @@ Uize = (function (_UizeOverrides) {
 			return _target;
 		}
 
-		function _copySourceIntoTarget(_target, _source) {
+		function _copySourceIntoTarget (_target,_source) {
 			for (var _property in _source)
-				_target[_property] = _source[_property]
+				_target [_property] = _source [_property]
 			;
 			return _target;
 		}
-		function _copyNewFromSourceIntoTarget (_target, _source) {
+		function _copyNewFromSourceIntoTarget (_target,_source) {
 			for (var _property in _source) {
 				//Only copy if it is a new property
 				if (!(_property in _target)) {
-					_target[_property] = _source[_property];
+					_target [_property] = _source [_property];
 				}
 			}
 			return _target;

--- a/site-source/js/Uize.js
+++ b/site-source/js/Uize.js
@@ -26,6 +26,21 @@
 			Utility Belt Methods
 				The =Uize= module provides a slew of utility belt methods that can be divided into the following categories...
 
+				Uize Overrides
+					=Uize= functions can be overriden by defining a =Uize= function before loading of the Uize module. For example...
+
+					....................................................................................
+					window.Uize = window.Uize || function(){};
+					Uize.moduleUrlResolver = function (_moduleName) {
+						var _modulePath = Uize.modulePathResolver (_moduleName);
+						return (
+							moduleName.indexOf ('MyDomain.') == 0
+								? '/js/' + _modulePath + '.js'
+								: 'http://www.some-cdn.com/uize-js/' + _modulePath + '.js'
+						);
+					};
+					....................................................................................
+
 				Module Mechanism Methods
 					The =Uize= module provides static methods for declaring your own JavaScript modules, requiring modules, and configuring the `module loader mechanism` to suit your application environment.
 
@@ -299,12 +314,12 @@
 						This is just like immediate invokation of an anonymous function, except with the additional wrapper of the =Uize.quarantine= call.
 */
 
-Uize = (function () {
+Uize = (function (_UizeOverrides) {
 	'use strict';
 
 		var
 			/*** Variables for Scruncher Optimization ***/
-				_package = function () {},
+				_package = _UizeOverrides || function () { },
 				_undefined,
 				_typeString = 'string',
 				_typeObject = 'object',
@@ -392,10 +407,19 @@ Uize = (function () {
 			return _target;
 		}
 
-		function _copySourceIntoTarget (_target,_source) {
+		function _copySourceIntoTarget(_target, _source) {
 			for (var _property in _source)
-				_target [_property] = _source [_property]
+				_target[_property] = _source[_property]
 			;
+			return _target;
+		}
+		function _copyNewFromSourceIntoTarget (_target, _source) {
+			for (var _property in _source) {
+				//Only copy if it is a new property
+				if (!(_property in _target)) {
+					_target[_property] = _source[_property];
+				}
+			}
 			return _target;
 		}
 
@@ -414,7 +438,7 @@ Uize = (function () {
 			;
 		}
 
-	_copySourceIntoTarget (
+	_copyNewFromSourceIntoTarget (
 		_package,
 		{
 			capFirstChar:function (_sourceStr) {
@@ -5400,7 +5424,7 @@ Uize = (function () {
 			);
 		}
 
-		_copySourceIntoTarget (
+		_copyNewFromSourceIntoTarget(
 			_package,
 			{
 				getModuleByName:_getModuleByName = function (_moduleName) {
@@ -6049,5 +6073,5 @@ Uize = (function () {
 		_package.addFolderOrgNamespaces ('Uize');
 		_package.module ({name:'Uize',builder:function () {return _package}});
 
-	return _package;
-}) ();
+		return _package;
+}) ((function () {return this}) ().Uize);


### PR DESCRIPTION
Presently Uize static functions can be overridden. moduleUrlResolver is specifically designed to be overridden. However Uize.js must be loaded first, which would require special casing the Uize.js load.

This changes Uize so you can specify overrides before Uize.js is loaded, that way any existing override code can be moved before the Uize.js load without requiring changes.

We have tested this change for a week on QA and didn't notice any issues, and now it is live on www.zazzle.com .

Let me know if anything is fishy about this code, or if you think it should be done in a different way.

Thanks!
Quentin Brooks