### PR TITLE
Update path resolution windows

### DIFF
--- a/build.js
+++ b/build.js
@@ -77,7 +77,7 @@ function _eval (_toEval) {
 				_folderExists
 			;
 			function _resolvePath (_path) {
-				return /^\.?\//.test (_path) ? _path : _pathToRoot + _path;
+				return /^(\.?\/|[a-z]:|\.?\\)/i.test (_path) ? _path : _pathToRoot + _path;
 			}
 			if (_isWsh) {
 				_fileSystem = new ActiveXObject ('Scripting.FileSystemObject');

--- a/build.js
+++ b/build.js
@@ -77,7 +77,7 @@ function _eval (_toEval) {
 				_folderExists
 			;
 			function _resolvePath (_path) {
-				return /^(\.?\/|[a-z]:|\.?\\)/i.test (_path) ? _path : _pathToRoot + _path;
+				return /^(\.?\/|[a-z]:|\\)/i.test (_path) ? _path : _pathToRoot + _path;
 			}
 			if (_isWsh) {
 				_fileSystem = new ActiveXObject ('Scripting.FileSystemObject');


### PR DESCRIPTION
Hi, I'm trying to use UIZE under Windows and found an issue with ``_resolvePath``. 
It tests path for starting from ``./`` or ``/``, but does not expect something like ``C:\path`` or ``\path``.
This PR extends check to support [Windows paths format](https://docs.microsoft.com/ru-ru/dotnet/standard/io/file-path-formats).